### PR TITLE
Use MediaStreamTrack.stop() to stop streaming, not MediaStream.stop()

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name:'hitchcott:qr-scanner',
-  version:'1.0.0',
+  version:'1.0.1',
   summary: 'A QR Code Scanner (using jsqrcode)',
   git: "https://github.com/hitchcott/meteor-qr-code-scanner.git"
 });

--- a/qr-scanner.coffee
+++ b/qr-scanner.coffee
@@ -45,9 +45,7 @@ Template._qrScanner.destroyed = ->
 
 stopCapture = ->
   if localMediaStream
-    try
-      localMediaStream.stop()
-      localMediaStream.active = false
+    localMediaStream.getTracks()[0].stop()
   if localMediaInterval
     Meteor.clearInterval localMediaInterval
   showingCanvas = false


### PR DESCRIPTION
MediaStream.stop() has been deprecated in favor of MediaStreamTrack.stop(). See https://developers.google.com/web/updates/2015/07/mediastream-deprecations?hl=en.

I did some research and Chrome, Firefox, Opera, IE Edge etc. are all using MediaStreamTrack.stop().

MediaStream.stop() still works in some browsers for now. But for example in Chrome it will be completely removed in the next stable release (Chrome 47) due in November 2015.

@hitchcott: Can you please merge this PR and publish a new version on Atmosphere. Thanks :smiley: 
