### PR TITLE
Ability to stop and restart capture without refreshing the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add the video streaming template to your app.
 {{> qrScanner}}
 ```
 
-You can access the latest succesfully decoded message through the reactive variable `message`.
+You can access the latest successfully decoded message through the reactive variable `message`.
 
 ```
 Template.myTmpl.qrCode = -> qrScanner.message()
@@ -47,7 +47,7 @@ At any time you can access image data from the scanner using the following:
 
 ## Video Quality
 
-You can specify a [relatively](http://stackoverflow.com/a/15434766/2682159) specific video resolution if you want, but it can become a jumpy on mobile devices. More pixel data is needed to be analysed with higher resolutions. The default is 640 x 480.
+You can specify a [relatively](http://stackoverflow.com/a/15434766/2682159) specific video resolution if you want, but it can become a jumpy on mobile devices. More pixel data is needed to be analyzed with higher resolutions. The default is 640 x 480.
 
 ```
 {{> qrScanner w=1024 h=768}}
@@ -56,7 +56,7 @@ You can specify a [relatively](http://stackoverflow.com/a/15434766/2682159) spec
 The default resolution is 320 x 240 px, which works smoothly and effectively on a Galaxy S4.
 
 
-## Stop Caputure
+## Stop Capture
 
 Use the following to stop capturing
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name:'hitchcott:qr-scanner',
-  version:'1.0.2',
+  version:'1.0.3',
   summary: 'A QR Code Scanner (using jsqrcode)',
   git: "https://github.com/hitchcott/meteor-qr-code-scanner.git"
 });

--- a/qr-scanner.coffee
+++ b/qr-scanner.coffee
@@ -49,6 +49,7 @@ stopCapture = ->
       track.stop()
   if localMediaInterval
     Meteor.clearInterval localMediaInterval
+    localMediaInterval = null
   showingCanvas = false
   qrReactiveDict.set 'message', null
   qrScanner.off 'scan'


### PR DESCRIPTION
Hi @hitchcott, I've fixed another small bug.

If I scan a QR code and then call `qrScanner.stopCapture()`, everything stops correctly. But if I go to another page (e.g., via iron router or Flow Router) and then come back to the page and load the qrScanner again, this time I am not able to scan the QR code. The way I got around this so far was to refresh the page with `location.reload()` after a user had scanned a QR code.

This bug happens because the interval that is supposed to start on [line 104](https://github.com/hitchcott/meteor-qr-code-scanner/blob/master/qr-scanner.coffee#L104) doesn't start. [Line 103](https://github.com/hitchcott/meteor-qr-code-scanner/blob/master/qr-scanner.coffee#L103) checks that `localMediaInterval` is null. Thus if `localMediaInterval` is `18` for example then the interval is not started again.

This happens because `localMediaInterval` isn't set to null when I call `qrScanner.stopCapture()`. It should be set to null at the same time as clearing the Meteor interval on [line 51](https://github.com/hitchcott/meteor-qr-code-scanner/blob/master/qr-scanner.coffee#L51).

If this is not clear I can setup a demo or try to explain it in another manner.

I've also fixed some very minor typos in the README and I bumped the version to 1.0.3.

I'll use my local package until you publish the new version on Atmosphere. Cheers!
