### PR TITLE
Don't Parse undefined Media Sources

### DIFF
--- a/qr-scanner.coffee
+++ b/qr-scanner.coffee
@@ -91,6 +91,7 @@ initWebcam = ->
     parseSources = (sourceInfos) ->
       for i in [0..sourceInfos.length]
         sourceInfo = sourceInfos[i]
+        continue unless sourceInfo?
         if sourceInfo.kind == 'video' && (sourceInfo.facing == '' || sourceInfo.facing == 'environment')\
         or sourceInfo.kind == 'videoinput' # for enumerateDevices
           optional_source = [sourceId: sourceInfo.id]


### PR DESCRIPTION
Package generates an error:

```
Uncaught TypeError: Cannot read property 'kind' of undefined
parseSources @ qr-scanner.coffee:94(anonymous function) @ qr-scanner.coffee:84
```

I've seen this most frequently on desktops, esp. without webcams.

By skipping `undefined` media sources we avoid asking for properties of `undefined` objects.
